### PR TITLE
[Fix]: Add camera format optimization for high-quality photos

### DIFF
--- a/app/scanner.tsx
+++ b/app/scanner.tsx
@@ -10,6 +10,7 @@ import { useScanMode } from "@/modules/core/hooks/use-scan-mode";
 import { useImagePreview } from "@/modules/core/hooks/use-image-preview";
 import { useGalleryPicker } from "@/modules/core/hooks/use-gallery-picker";
 import { useNavigation } from "@/modules/core/hooks/use-navigation";
+import { useCameraFormatForPhotos } from "@/modules/core/hooks/use-camera-format";
 
 // Components
 import { ScannerHeader } from "@/modules/core/components/scanner/scanner-header";
@@ -26,6 +27,9 @@ const cameraHeight = screenHeight * 0.7;
 export default function ScannerScreen() {
   // Camera device - debe ir primero
   const device = useCameraDevice("back");
+  
+  // Formato optimizado para fotos de alta calidad
+  const format = useCameraFormatForPhotos({ device });
 
   // Custom hooks
   const { hasPermission, requestCameraAccess } = useCameraPermission();
@@ -162,6 +166,7 @@ export default function ScannerScreen() {
                 onZoomOut={zoomOut}
                 onResetZoom={resetZoom}
                 gesture={zoomGesture}
+                format={format}
               />
             )}
           </View>

--- a/modules/core/components/scanner/camera-preview.tsx
+++ b/modules/core/components/scanner/camera-preview.tsx
@@ -17,6 +17,7 @@ interface CameraPreviewProps {
   onZoomOut: () => void;
   onResetZoom: () => void;
   gesture: any;
+  format?: any; // Formato optimizado para la cámara
 }
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
@@ -32,6 +33,7 @@ export const CameraPreview = ({
   onZoomOut,
   onResetZoom,
   gesture,
+  format,
 }: CameraPreviewProps) => {
   if (!device || !isActive) {
     return (
@@ -51,6 +53,7 @@ export const CameraPreview = ({
           ref={camera}
           style={StyleSheet.absoluteFill}
           device={device}
+          format={format}
           isActive={true}
           photo={true}
           video={false}
@@ -58,6 +61,8 @@ export const CameraPreview = ({
           torch={flashEnabled ? "on" : "off"}
           zoom={currentZoom}
           enableZoomGesture={false}
+          photoQualityBalance="quality"
+          photoHdr={format?.supportsPhotoHdr}
         />
 
         <View className="absolute z-10">

--- a/modules/core/hooks/use-camera-focus-zoom.ts
+++ b/modules/core/hooks/use-camera-focus-zoom.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { Gesture } from "react-native-gesture-handler";
 import { runOnJS } from "react-native-reanimated";
 import type { CameraDevice } from "react-native-vision-camera";
@@ -8,7 +8,14 @@ interface UseCameraFocusZoomProps {
 }
 
 export const useCameraFocusZoom = ({ device }: UseCameraFocusZoomProps) => {
-  const [currentZoom, setCurrentZoom] = useState(1);
+  const [currentZoom, setCurrentZoom] = useState(device?.neutralZoom || 1);
+
+  // Sincronizar zoom inicial cuando el device cambie
+  useEffect(() => {
+    if (device?.neutralZoom) {
+      setCurrentZoom(device.neutralZoom);
+    }
+  }, [device]);
 
   const setZoom = useCallback(
     (zoomLevel: number) => {

--- a/modules/core/hooks/use-camera-format.ts
+++ b/modules/core/hooks/use-camera-format.ts
@@ -1,0 +1,24 @@
+import { useCameraFormat } from "react-native-vision-camera";
+import type { CameraDevice } from "react-native-vision-camera";
+
+interface UseCameraFormatForPhotosProps {
+  device: CameraDevice | undefined;
+}
+
+/**
+ * Hook para obtener un formato de cámara optimizado para tomar fotos de alta calidad
+ */
+export const useCameraFormatForPhotos = ({
+  device,
+}: UseCameraFormatForPhotosProps) => {
+  const format = useCameraFormat(device, [
+    // Priorizar máxima resolución de foto
+    { photoResolution: "max" },
+    // Asegurar resolución mínima decente para preview
+    { videoResolution: { width: 1280, height: 720 } },
+    // HDR si está disponible
+    { photoHdr: true },
+  ]);
+
+  return format;
+};


### PR DESCRIPTION
This pull request introduces improvements to the camera functionality in the scanner module, focusing on optimizing photo quality and ensuring a better user experience when taking pictures. The main changes include adding a custom hook to select the best camera format for high-quality photos, updating components to use this optimized format, and synchronizing the initial zoom level with the camera device's neutral zoom.

**Camera format optimization:**

* Added a new hook `useCameraFormatForPhotos` that selects the optimal camera format for high-quality photos, prioritizing maximum photo resolution, minimum preview resolution, and enabling HDR if available (`modules/core/hooks/use-camera-format.ts`).
* Updated `ScannerScreen` to use the new `useCameraFormatForPhotos` hook and pass the selected format to the camera preview (`app/scanner.tsx`) [[1]](diffhunk://#diff-07a70863e6d10639be387418a113f8d82ddc9cd7563885b419766d6fa9664c70R13) [[2]](diffhunk://#diff-07a70863e6d10639be387418a113f8d82ddc9cd7563885b419766d6fa9664c70R31-R33) [[3]](diffhunk://#diff-07a70863e6d10639be387418a113f8d82ddc9cd7563885b419766d6fa9664c70R169).

**Camera preview enhancements:**

* Modified the `CameraPreview` component to accept a `format` prop and use it when rendering the camera, including setting `photoQualityBalance` to "quality" and enabling HDR if supported (`modules/core/components/scanner/camera-preview.tsx`) [[1]](diffhunk://#diff-67d72e400258af34027a3854559e5f6167b815d10c0cb959743cab54bf8903efR20) [[2]](diffhunk://#diff-67d72e400258af34027a3854559e5f6167b815d10c0cb959743cab54bf8903efR36) [[3]](diffhunk://#diff-67d72e400258af34027a3854559e5f6167b815d10c0cb959743cab54bf8903efR56-R65).

**Zoom initialization improvement:**

* Updated the `useCameraFocusZoom` hook to initialize and synchronize the zoom level with the camera device's `neutralZoom` value, ensuring consistent zoom behavior when the device changes (`modules/core/hooks/use-camera-focus-zoom.ts`) [[1]](diffhunk://#diff-2a93d0ff015ebf84ee0252f11d9bc821d5aefe5b34c9bb1770e3fd042e7fbfa5L1-R1) [[2]](diffhunk://#diff-2a93d0ff015ebf84ee0252f11d9bc821d5aefe5b34c9bb1770e3fd042e7fbfa5L11-R18).